### PR TITLE
add step to prs to upload build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,14 @@ jobs:
 
       - name: Test
         run: nr test
+
+      - name: Build Unpacked Plugin
+        run: |
+          mkdir logseq-graph-analysis
+          cp package.json README.md logseq-graph-analysis
+          mv dist logseq-graph-analysis
+          zip -r logseq-graph-analysis.zip logseq-graph-analysis
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: logseq-graph-analysis.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,12 @@ jobs:
           cp package.json README.md logseq-graph-analysis
           mv dist logseq-graph-analysis
 
+      - uses: jwalton/gh-find-current-pr@v1
+        id: findPr
+        with:
+          state: open
+
       - uses: actions/upload-artifact@v3
         with:
-          name: logseq-graph-analysis
+          name: logseq-graph-analysis-${{ steps.findPr.outputs.pr }}
           path: logseq-graph-analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
           mkdir logseq-graph-analysis
           cp package.json README.md logseq-graph-analysis
           mv dist logseq-graph-analysis
-          zip -r logseq-graph-analysis.zip logseq-graph-analysis
 
       - uses: actions/upload-artifact@v3
         with:
-          path: logseq-graph-analysis.zip
+          name: logseq-graph-analysis
+          path: logseq-graph-analysis


### PR DESCRIPTION
when some creates a pull request against my repo it will now build a unpacked plugin that can be loaded in logseq and attaches it as a build artifact to download.

To get to these build artifacts click:

1. show all checks
2. details
3. summary
4. scroll down