### PR TITLE
adding a second slider for nodes that are not highlighted to see high…

### DIFF
--- a/src/Settings.svelte
+++ b/src/Settings.svelte
@@ -42,6 +42,10 @@
       <option selected value="in">inbound links</option>
       <option value="out">outbound links</option>
     </select>
+    <div>
+      <label for="nodeSize">node size</label>
+      <input class="slider nodeSize" type="range" min="0.01" step="0.1" max="3" bind:value={$settings.nodeSize} />
+    </div>
   </div>
   <hr />
   <div>
@@ -75,8 +79,8 @@
       <input type="text" bind:value={$settings.pathA} />
     </div>
     <div>
-      <label for="bubbleSize">bubble size</label>
-      <input type="range" min="0.01" step="0.1" max="10" bind:value={$settings.bubbleSize} />
+      <label for="bubbleSize">highlighted note size</label>
+      <input class="slider highlightedNodeSize" type="range" min="0.01" step="0.1" max="10" bind:value={$settings.highlightedNodeSize} />
     </div>
   {/if}
 </div>
@@ -93,4 +97,51 @@
     margin: 0;
     background-color: rgba(255, 255, 255, 0.8);
   }
+  .slider {
+    width: 100%;
+    height: 1.5em;
+    background: #fff;
+    outline: none;
+    opacity: 0.7;
+    -webkit-transition: .2s;
+    -webkit-appearance: none;
+    transition: opacity .2s;
+  }
+  .slider:hover {
+    opacity: 0.8;
+  }
+  .slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    border-radius: 1.5em;
+    border: 1px solid #b2b2b2;
+    appearance: none;
+    width: 1.5em;
+    height: 1.5em;
+    cursor: pointer;
+    margin-top: -0.5em; 
+    margin-bottom: -0.5em;
+  }
+  .slider::-webkit-slider-runnable-track {
+    height: 0.7em;
+    border: 1px solid #b2b2b2;
+    border-radius: 0.5em;
+  }
+  .slider::-moz-range-thumb {
+    width: 1.5em;
+    height: 1.5em;
+    cursor: pointer;
+  }
+  .nodeSize {color: grey;}
+  .nodeSize::-webkit-slider-thumb {background: grey;}
+  .nodeSize::-webkit-slider-runnable-track {background: lightgray;}
+  .nodeSize::-moz-range-thumb {background: grey}
+  .highlightedNodeSize {color: #f87171}
+  .highlightedNodeSize::-webkit-slider-thumb {background: #f87171;}
+  .highlightedNodeSize::-webkit-slider-runnable-track {background: #FFCCCC;}
+  .highlightedNodeSize::-moz-range-thumb {background: #f87171}
+
 </style>
+
+
+
+

--- a/src/Sigma.svelte
+++ b/src/Sigma.svelte
@@ -88,6 +88,11 @@
       res.size = maxSize(Math.max(2, graph.neighbors(node).length / 2), 16);
     } else if ($settings.size === "out") {
       res.size = maxSize(graph.inDegree(node), 16);
+    } 
+
+    if (res.size) {
+      res.size = $settings.nodeSize * res.size;
+      if (res.size<1) {res.size = 1 }
     }
 
     const label = res.label?.toUpperCase();
@@ -103,6 +108,8 @@
       res.size = (res.size ?? data.size) + 2;
       res.highlighted = true;
     }
+
+
 
     if ($settings.mode === Mode.ShortestPath) {
       const pathA =
@@ -134,7 +141,7 @@
       } else if (adamicAdarResults[node]) {
         res.color = red;
         res.size = maxSize(
-          $settings.bubbleSize * adamicAdarResults[node].measure,
+          $settings.highlightedNodeSize * adamicAdarResults[node].measure,
           32
         );
         res.label = `${adamicAdarResults[node].measure} ${data.label}`;
@@ -149,12 +156,12 @@
         res.color = orange;
         res.highlighted = true;
       } else if (coCitationResults[node]) {
+        res.zIndex = 2;
         res.color = red;
-        res.size = $settings.bubbleSize * coCitationResults[node].measure;
+        res.size = $settings.highlightedNodeSize * coCitationResults[node].measure;
         res.label = `${coCitationResults[node].measure} ${data.label}`;
       }
     }
-
     return res;
   };
 

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -18,7 +18,8 @@ interface Settings {
   gravity: number;
   mode: Mode;
   directed: boolean;
-  bubbleSize: number;
+  nodeSize: number;
+  highlightedNodeSize: number;
 }
 
 interface Store {
@@ -65,5 +66,6 @@ export const settings: Writable<Settings> = writable({
   gravity: 0.05,
   mode: Mode.Navigate,
   directed: true,
-  bubbleSize: 5,
+  nodeSize: 1,
+  highlightedNodeSize: 5
 });


### PR DESCRIPTION
Hi Stephen, 

I've been playing quite a bit with the graph. It's so helpful in discovery! 

In quite a few cases, the graph was so dense that highlighted notes from Adar or Cocitation were hidden behind the mesh of nodes. It looks like Sigma / Graphology ignores the z-index. 

After toying around, i've created another size slider. A grey one for the grey nodes, a red one for the highlighted red nodes. Together it gives more display control. 

Not sure if it's the best usability, so please feel free to ignore or change if you don't like it.

Bye, Arthur