### PR TITLE
feature: Skip pages with `exclude-from-graph-view: true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Learn more about the relationships between between your notes using network anal
   - Adamic Adar - Find secret connections between your notes. Click a note to learn which notes the algorithm thinks are linked
   - CoCitation - Checks how alike documents are by looking at how close their shared references are
 - Shift-click node to add it to sidebar
-- If there are nodes you wish to hide from your graph add the page property `graph-hide:: true`
+- If there are nodes you wish to hide from your graph add the page property `graph-hide:: true` or `exclude-from-graph-view:: true`
+  - `graph-hide:: true` hides nodes from this plugin's `graph analysis` mode
+  - `exclude-from-graph-view:: true` hides nodes from both this plugin and Logseq's native global graph view, see [the Logseq documentation](https://docs.logseq.com/#/page/built-in%20properties)
   - If you are interested in seeing suprising paths in your notes its a good idea to add this to notes that have lots of connections.
 
 ## Search and filters

--- a/src/__snapshots__/graph.ts.snap
+++ b/src/__snapshots__/graph.ts.snap
@@ -396,6 +396,30 @@ exports[`buildGraph > shows journal pages when requested 1`] = `
 }
 `;
 
+exports[`buildGraph > skips pages with exclude-from-graph-view: true 1`] = `
+{
+  "attributes": {
+    "isInited": true,
+  },
+  "edges": [],
+  "nodes": [
+    {
+      "attributes": {
+        "aliases": [],
+        "label": "A",
+        "rawAliases": [],
+        "type": "circle",
+      },
+    },
+  ],
+  "options": {
+    "allowSelfLoops": true,
+    "multi": false,
+    "type": "mixed",
+  },
+}
+`;
+
 exports[`buildGraph > skips pages with graph-hide: true 1`] = `
 {
   "attributes": {

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -34,7 +34,7 @@ export async function buildGraph(
   const journals = pages.filter((p) => p["journal?"]);
 
   for (const page of pages) {
-    if (page.properties && page.properties.graphHide) {
+    if (page.properties && (page.properties.graphHide || page.properties.excludeFromGraphView)) {
       continue;
     }
     if (g.hasNode(page.id)) {

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -445,6 +445,36 @@ if (import.meta.vitest) {
       expect(graphToJson(graph)).toMatchSnapshot();
     });
 
+    it("skips pages with exclude-from-graph-view: true", async () => {
+      const getAllPages = async () => [
+        { id: 1, "journal?": false, name: "A" },
+        {
+          id: 2,
+          "journal?": false,
+          name: "B",
+          properties: { excludeFromGraphView: true },
+        },
+      ];
+      const getBlockReferences = async () => [
+        [
+          {
+            refs: [{ id: 2 }],
+            "path-refs": [{ id: 1 }, { id: 2 }],
+            page: { id: 1 },
+          },
+        ],
+      ];
+      const getSettings = () => ({ journal: false });
+      const getBlock = async (ref: BlockIdentity | EntityID) => null;
+      const graph = await buildGraph(
+        getAllPages,
+        getBlockReferences,
+        getSettings,
+        getBlock
+      );
+      expect(graphToJson(graph)).toMatchSnapshot();
+    });
+
     it("merges alias nodes", async () => {
       const getAllPages = async () => [
         { id: 1, "journal?": false, name: "A", properties: { alias: ["B"] } },

--- a/src/logseq.ts
+++ b/src/logseq.ts
@@ -10,6 +10,7 @@ export interface Page {
   name: string;
   properties?: {
     graphHide?: boolean;
+    excludeFromGraphView?: boolean;
     alias?: string[] | string;
     icon?: string;
     pageIcon?: string;


### PR DESCRIPTION
Fixes #65 

Extends the schema so this plugin can read the `exclude-from-graph-view` property and exclude any nodes that have the property set to `true`.